### PR TITLE
Update parent pom and liquibase config for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target/
 # IntelliJ
 /.idea
 *.iml
+
+# https://github.com/liquibase/liquibase/issues/2196
+/derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>17</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 

--- a/src/test/resources/application-default.yml
+++ b/src/test/resources/application-default.yml
@@ -16,7 +16,7 @@ logging:
 powsybl-ws:
   database:
     vendor: h2:mem
-    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DEFAULT_NULL_ORDERING=HIGH
     hostPort: ":"
 
 useradmin:


### PR DESCRIPTION
Update POM parent, like on other projects using Liquibase, to keep up-to-date
* Also add missing compatibility mode in H2 configuration
* ⚠️ need release v18 of powsybl/powsybl-parent/pull/54