### PR TITLE
Fix records duplication

### DIFF
--- a/src/main/java/org/gridsuite/useradmin/server/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/gridsuite/useradmin/server/RestResponseEntityExceptionHandler.java
@@ -18,15 +18,14 @@ import static org.gridsuite.useradmin.server.UserAdminException.Type.FORBIDDEN;
  */
 @ControllerAdvice
 public class RestResponseEntityExceptionHandler {
-
     @ExceptionHandler(value = { UserAdminException.class })
     protected ResponseEntity<Object> handleException(RuntimeException exception) {
-        if (exception instanceof UserAdminException) {
-            UserAdminException userAdminException = (UserAdminException) exception;
-            if (userAdminException.getType().equals(FORBIDDEN)) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(userAdminException.getType());
-            }
+        if (exception instanceof UserAdminException userAdminException) {
+            return switch (userAdminException.getType()) {
+                case FORBIDDEN -> ResponseEntity.status(HttpStatus.FORBIDDEN).body(userAdminException.getType());
+            };
+        } else {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
 }

--- a/src/main/java/org/gridsuite/useradmin/server/UserAdminController.java
+++ b/src/main/java/org/gridsuite/useradmin/server/UserAdminController.java
@@ -72,4 +72,12 @@ public class UserAdminController {
     public ResponseEntity<List<ConnectionEntity>> getConnections(@RequestHeader("userId") String userId) {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(service.getConnections(userId));
     }
+
+    @Deprecated(forRemoval = true)
+    @GetMapping(value = "/connections/deduplicate")
+    @Operation(summary = "get the connections deduplicated", deprecated = true)
+    @ApiResponse(responseCode = "200", description = "The connections list")
+    public ResponseEntity<List<ConnectionEntity>> deduplicateConnections(@RequestHeader("userId") String userId) {
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(service.getDeduplicatedConnections(userId));
+    }
 }

--- a/src/main/java/org/gridsuite/useradmin/server/UserAdminException.java
+++ b/src/main/java/org/gridsuite/useradmin/server/UserAdminException.java
@@ -6,11 +6,16 @@
  */
 package org.gridsuite.useradmin.server;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import java.util.Objects;
 
 /**
  * @author Etienne Homer <etienne.homer at rte-france.com>
  */
+@EqualsAndHashCode(callSuper = false)
+@Data
 public class UserAdminException extends RuntimeException {
     public enum Type {
         FORBIDDEN
@@ -22,9 +27,4 @@ public class UserAdminException extends RuntimeException {
         super(Objects.requireNonNull(type.name()));
         this.type = type;
     }
-
-    Type getType() {
-        return type;
-    }
-
 }

--- a/src/main/java/org/gridsuite/useradmin/server/repository/AbstractUserEntity.java
+++ b/src/main/java/org/gridsuite/useradmin/server/repository/AbstractUserEntity.java
@@ -6,24 +6,32 @@
  */
 package org.gridsuite.useradmin.server.repository;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.UUID;
 
 /**
  * @author Etienne Homer <etienne.homer at rte-france.com>
  */
 @NoArgsConstructor
-//@AllArgsConstructor
+@AllArgsConstructor
 @Getter
 @Setter
-@Entity
-@Table(name = "user_infos", indexes = {@Index(name = "user_infos_sub_index", columnList = "sub")})
-public class UserInfosEntity extends AbstractUserEntity {
-    public UserInfosEntity(String sub) {
-        super(sub);
+@MappedSuperclass
+abstract class AbstractUserEntity {
+    public AbstractUserEntity(String sub) {
+        this(UUID.randomUUID(), sub);
     }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "sub", nullable = false, unique = true)
+    private String sub;
 }

--- a/src/main/java/org/gridsuite/useradmin/server/repository/ConnectionEntity.java
+++ b/src/main/java/org/gridsuite/useradmin/server/repository/ConnectionEntity.java
@@ -6,14 +6,16 @@
  */
 package org.gridsuite.useradmin.server.repository;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import jakarta.persistence.*;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 /**
  * @author Etienne Homer <etienne.homer at rte-france.com>
@@ -24,15 +26,7 @@ import java.util.UUID;
 @Setter
 @Entity
 @Table(name = "connection", indexes = {@Index(name = "connection_sub_index", columnList = "sub")})
-public class ConnectionEntity {
-
-    @Id
-    @Column(name = "id")
-    private UUID id;
-
-    @Column(name = "sub", nullable = false)
-    private String sub;
-
+public class ConnectionEntity extends AbstractUserEntity {
     @Column(name = "firstConnexionDate", nullable = false)
     private LocalDateTime firstConnexionDate;
 
@@ -43,6 +37,9 @@ public class ConnectionEntity {
     private Boolean connectionAccepted;
 
     public ConnectionEntity(String sub, LocalDateTime firstConnexionDate, LocalDateTime lastConnexionDate, Boolean connectionAccepted) {
-        this(UUID.randomUUID(), sub, firstConnexionDate, lastConnexionDate, connectionAccepted);
+        super(sub);
+        this.firstConnexionDate = firstConnexionDate;
+        this.lastConnexionDate = lastConnexionDate;
+        this.connectionAccepted = connectionAccepted;
     }
 }

--- a/src/main/java/org/gridsuite/useradmin/server/repository/ConnectionEntity.java
+++ b/src/main/java/org/gridsuite/useradmin/server/repository/ConnectionEntity.java
@@ -27,19 +27,19 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "connection", indexes = {@Index(name = "connection_sub_index", columnList = "sub")})
 public class ConnectionEntity extends AbstractUserEntity {
-    @Column(name = "firstConnexionDate", nullable = false)
-    private LocalDateTime firstConnexionDate;
+    @Column(name = "firstConnectionDate", nullable = false)
+    private LocalDateTime firstConnectionDate;
 
-    @Column(name = "lastConnexionDate", nullable = false)
-    private LocalDateTime lastConnexionDate;
+    @Column(name = "lastConnectionDate", nullable = false)
+    private LocalDateTime lastConnectionDate;
 
     @Column(name = "connectionAccepted", nullable = false)
     private Boolean connectionAccepted;
 
-    public ConnectionEntity(String sub, LocalDateTime firstConnexionDate, LocalDateTime lastConnexionDate, Boolean connectionAccepted) {
+    public ConnectionEntity(String sub, LocalDateTime firstConnectionDate, LocalDateTime lastConnectionDate, Boolean connectionAccepted) {
         super(sub);
-        this.firstConnexionDate = firstConnexionDate;
-        this.lastConnexionDate = lastConnexionDate;
+        this.firstConnectionDate = firstConnectionDate;
+        this.lastConnectionDate = lastConnectionDate;
         this.connectionAccepted = connectionAccepted;
     }
 }

--- a/src/main/java/org/gridsuite/useradmin/server/repository/ConnectionRepository.java
+++ b/src/main/java/org/gridsuite/useradmin/server/repository/ConnectionRepository.java
@@ -28,7 +28,7 @@ public interface ConnectionRepository extends JpaRepository<ConnectionEntity, UU
     @Modifying
     default void recordNewConnection(@NonNull final String sub, final boolean connectionAccepted) {
         this.findBySub/*IgnoreCase*/(sub).ifPresentOrElse(
-            conn -> this.save(conn.setLastConnexionDate(LocalDateTime.now()).setConnectionAccepted(connectionAccepted)),
+            conn -> this.save(conn.setLastConnectionDate(LocalDateTime.now()).setConnectionAccepted(connectionAccepted)),
             () -> this.save(new ConnectionEntity(sub, LocalDateTime.now(), LocalDateTime.now(), connectionAccepted))
         );
     }

--- a/src/main/java/org/gridsuite/useradmin/server/repository/lombok.config
+++ b/src/main/java/org/gridsuite/useradmin/server/repository/lombok.config
@@ -1,0 +1,1 @@
+lombok.accessors.chain = true

--- a/src/main/java/org/gridsuite/useradmin/server/service/ConnectionsService.java
+++ b/src/main/java/org/gridsuite/useradmin/server/service/ConnectionsService.java
@@ -11,8 +11,6 @@ import org.gridsuite.useradmin.server.repository.ConnectionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -32,15 +30,7 @@ public class ConnectionsService {
 
     @Transactional
     public void recordConnectionAttempt(String sub, Boolean isAllowed) {
-        ConnectionEntity connectionEntity = connectionRepository.findBySub(sub).stream().findFirst().orElse(null);
-        if (connectionEntity == null) {
-            //To avoid consistency issue we truncate the time to microseconds since postgres and h2 can only store a precision of microseconds
-            connectionEntity = new ConnectionEntity(sub, LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), isAllowed);
-            connectionRepository.save(connectionEntity);
-        } else {
-            connectionEntity.setLastConnectionDate(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS));
-            connectionEntity.setConnectionAccepted(isAllowed);
-        }
+        connectionRepository.recordNewConnection(sub, isAllowed);
     }
 
     @Deprecated(forRemoval = true)

--- a/src/main/java/org/gridsuite/useradmin/server/service/ConnectionsService.java
+++ b/src/main/java/org/gridsuite/useradmin/server/service/ConnectionsService.java
@@ -43,6 +43,7 @@ public class ConnectionsService {
         }
     }
 
+    @Deprecated(forRemoval = true)
     @Transactional
     public List<ConnectionEntity> removeDuplicates() {
         Map<String, List<ConnectionEntity>> connectionsBySub = connectionRepository.findAll().stream().collect(Collectors.groupingBy(ConnectionEntity::getSub));

--- a/src/main/java/org/gridsuite/useradmin/server/service/ConnectionsService.java
+++ b/src/main/java/org/gridsuite/useradmin/server/service/ConnectionsService.java
@@ -38,7 +38,7 @@ public class ConnectionsService {
             connectionEntity = new ConnectionEntity(sub, LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), isAllowed);
             connectionRepository.save(connectionEntity);
         } else {
-            connectionEntity.setLastConnexionDate(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS));
+            connectionEntity.setLastConnectionDate(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS));
             connectionEntity.setConnectionAccepted(isAllowed);
         }
     }
@@ -51,11 +51,11 @@ public class ConnectionsService {
         connectionsBySub.keySet().forEach(sub ->
             connectionsBySub.get(sub).stream().skip(1).forEach(connectionEntity -> {
                 ConnectionEntity groupedEntity = connectionsBySub.get(sub).get(0);
-                if (connectionEntity.getLastConnexionDate().isAfter(groupedEntity.getLastConnexionDate())) {
-                    groupedEntity.setLastConnexionDate(connectionEntity.getLastConnexionDate());
+                if (connectionEntity.getLastConnectionDate().isAfter(groupedEntity.getLastConnectionDate())) {
+                    groupedEntity.setLastConnectionDate(connectionEntity.getLastConnectionDate());
                 }
-                if (connectionEntity.getFirstConnexionDate().isBefore(groupedEntity.getFirstConnexionDate())) {
-                    groupedEntity.setFirstConnexionDate(connectionEntity.getFirstConnexionDate());
+                if (connectionEntity.getFirstConnectionDate().isBefore(groupedEntity.getFirstConnectionDate())) {
+                    groupedEntity.setFirstConnectionDate(connectionEntity.getFirstConnectionDate());
                 }
                 connectionRepository.delete(connectionEntity);
             })

--- a/src/main/resources/db/changelog/changesets/changelog_20240109T161028Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20240109T161028Z.xml
@@ -1,0 +1,33 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="chuinetri" id="1704818243021-0">
+        <comment>Deduplicate rows before adding unique constraint</comment>
+        <delete tableName="user_infos">
+            <where>id in (select id from (select row_number() over (partition by sub) as rnb, * from user_infos) subquery where rnb > 1)</where>
+        </delete>
+
+        <sql stripComments="true" dbms="!oracle">
+            update connection c1 set
+                first_connexion_date = (select min(c2.first_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
+                last_connexion_date =  (select max(c2.last_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
+                connection_accepted =  (select connection_accepted from connection c2 where (c2.sub, c2.last_connexion_date) in (
+                    select c3.sub, max(c3.last_connexion_date) from connection c3 where c3.sub=c1.sub group by c3.sub) limit 1);
+        </sql>
+        <sql stripComments="true" dbms="oracle">
+            --oracle use fetch instead of limit
+            update connection c1 set
+            first_connexion_date = (select min(c2.first_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
+            last_connexion_date =  (select max(c2.last_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
+            connection_accepted =  (select connection_accepted from connection c2 where (c2.sub, c2.last_connexion_date) in (
+                select c3.sub, max(c3.last_connexion_date) from connection c3 where c3.sub=c1.sub group by c3.sub) FETCH FIRST 1 ROW ONLY);
+        </sql>
+        <delete tableName="connection">
+            <where>id in (select id from (select row_number() over (partition by sub) as rnb, * from connection) subquery where rnb > 1)</where>
+        </delete>
+    </changeSet>
+
+    <changeSet author="chuinetri" id="1704818243021-1">
+        <addUniqueConstraint columnNames="sub" constraintName="UC_USER_INFOSSUB_COL" tableName="user_infos"/>
+        <addUniqueConstraint columnNames="sub" constraintName="UC_CONNECTIONSUB_COL" tableName="connection"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20240109T161028Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20240109T161028Z.xml
@@ -1,7 +1,7 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
     <changeSet author="chuinetri" id="1704818243021-1">
-        <comment>Deduplicate rows before adding unique constraint</comment>
+        <comment>Deduplicate rows before adding unique constraints</comment>
         <delete tableName="user_infos">
             <where>id in (select id from (select row_number() over (partition by sub) as rnb, * from user_infos) subquery where rnb > 1)</where>
         </delete>
@@ -9,21 +9,23 @@
         <sql stripComments="true" dbms="!oracle">
             update connection c1 set
                 first_connexion_date = (select min(c2.first_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
-                last_connexion_date =  (select max(c2.last_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
-                connection_accepted =  (select connection_accepted from connection c2 where (c2.sub, c2.last_connexion_date) in (
+                last_connexion_date = (select max(c2.last_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
+                connection_accepted = (select connection_accepted from connection c2 where (c2.sub, c2.last_connexion_date) in (
                     select c3.sub, max(c3.last_connexion_date) from connection c3 where c3.sub=c1.sub group by c3.sub) limit 1);
         </sql>
         <sql stripComments="true" dbms="oracle">
             --oracle use fetch instead of limit
             update connection c1 set
-            first_connexion_date = (select min(c2.first_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
-            last_connexion_date =  (select max(c2.last_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
-            connection_accepted =  (select connection_accepted from connection c2 where (c2.sub, c2.last_connexion_date) in (
-                select c3.sub, max(c3.last_connexion_date) from connection c3 where c3.sub=c1.sub group by c3.sub) FETCH FIRST 1 ROW ONLY);
+                first_connexion_date = (select min(c2.first_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
+                last_connexion_date = (select max(c2.last_connexion_date) from connection c2 where c2.sub=c1.sub group by c2.sub),
+                connection_accepted = (select connection_accepted from connection c2 where (c2.sub, c2.last_connexion_date) in (
+                    select c3.sub, max(c3.last_connexion_date) from connection c3 where c3.sub=c1.sub group by c3.sub) FETCH FIRST 1 ROW ONLY);
         </sql>
         <delete tableName="connection">
             <where>id in (select id from (select row_number() over (partition by sub) as rnb, * from connection) subquery where rnb > 1)</where>
         </delete>
+
+        <rollback/><!--no rollback possible because delete, but no need as we just removed duplicate records-->
     </changeSet>
 
     <changeSet author="chuinetri" id="1704818243021-2">

--- a/src/main/resources/db/changelog/changesets/changelog_20240109T161028Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20240109T161028Z.xml
@@ -1,6 +1,6 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-    <changeSet author="chuinetri" id="1704818243021-0">
+    <changeSet author="chuinetri" id="1704818243021-1">
         <comment>Deduplicate rows before adding unique constraint</comment>
         <delete tableName="user_infos">
             <where>id in (select id from (select row_number() over (partition by sub) as rnb, * from user_infos) subquery where rnb > 1)</where>
@@ -26,8 +26,13 @@
         </delete>
     </changeSet>
 
-    <changeSet author="chuinetri" id="1704818243021-1">
+    <changeSet author="chuinetri" id="1704818243021-2">
         <addUniqueConstraint columnNames="sub" constraintName="UC_USER_INFOSSUB_COL" tableName="user_infos"/>
         <addUniqueConstraint columnNames="sub" constraintName="UC_CONNECTIONSUB_COL" tableName="connection"/>
+    </changeSet>
+
+    <changeSet author="chuinetri" id="1704818243021-3">
+        <renameColumn tableName="connection" oldColumnName="first_connexion_date" newColumnName="first_connection_date"/>
+        <renameColumn tableName="connection" oldColumnName="last_connexion_date" newColumnName="last_connection_date"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,9 +1,10 @@
 databaseChangeLog:
-
   - include:
       file: changesets/changelog_20220921T091049Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220930T080149Z.xml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20240109T161028Z.xml
       relativeToChangelogFile: true

--- a/src/test/java/org/gridsuite/useradmin/server/UserAdminTest.java
+++ b/src/test/java/org/gridsuite/useradmin/server/UserAdminTest.java
@@ -116,14 +116,14 @@ public class UserAdminTest {
         assertEquals(3, connectionRepository.findAll().size());
         assertTrue(connectionRepository.findBySub(USER_SUB).get().getConnectionAccepted());
         assertFalse(connectionRepository.findBySub("UNKNOWN").get().getConnectionAccepted());
-        LocalDateTime firstConnectionDate = connectionRepository.findBySub(USER_SUB).get().getFirstConnexionDate();
+        LocalDateTime firstConnectionDate = connectionRepository.findBySub(USER_SUB).get().getFirstConnectionDate();
         //firstConnectionDate and lastConnectionDate are equals cause this is the first connection for this user
-        assertTrue(firstConnectionDate.toEpochSecond(ZoneOffset.UTC) < connectionRepository.findBySub(USER_SUB).get().getLastConnexionDate().toEpochSecond(ZoneOffset.UTC) + 2);
+        assertTrue(firstConnectionDate.toEpochSecond(ZoneOffset.UTC) < connectionRepository.findBySub(USER_SUB).get().getLastConnectionDate().toEpochSecond(ZoneOffset.UTC) + 2);
 
         mockMvc.perform(head("/" + UserAdminApi.API_VERSION + "/users/{sub}", USER_SUB))
                 .andExpect(status().isOk())
                 .andReturn();
-        assertEquals(firstConnectionDate, connectionRepository.findBySub(USER_SUB).get().getFirstConnexionDate());
+        assertEquals(firstConnectionDate, connectionRepository.findBySub(USER_SUB).get().getFirstConnectionDate());
 
         mockMvc.perform(delete("/" + UserAdminApi.API_VERSION + "/users/{id}", userId)
                         .header("userId", ADMIN_USER)

--- a/src/test/java/org/gridsuite/useradmin/server/UserAdminTest.java
+++ b/src/test/java/org/gridsuite/useradmin/server/UserAdminTest.java
@@ -114,16 +114,16 @@ public class UserAdminTest {
                 .andExpect(status().isNoContent())
                 .andReturn();
         assertEquals(3, connectionRepository.findAll().size());
-        assertTrue(connectionRepository.findBySub(USER_SUB).get(0).getConnectionAccepted());
-        assertFalse(connectionRepository.findBySub("UNKNOWN").get(0).getConnectionAccepted());
-        LocalDateTime firstConnectionDate = connectionRepository.findBySub(USER_SUB).get(0).getFirstConnexionDate();
+        assertTrue(connectionRepository.findBySub(USER_SUB).get().getConnectionAccepted());
+        assertFalse(connectionRepository.findBySub("UNKNOWN").get().getConnectionAccepted());
+        LocalDateTime firstConnectionDate = connectionRepository.findBySub(USER_SUB).get().getFirstConnexionDate();
         //firstConnectionDate and lastConnectionDate are equals cause this is the first connection for this user
-        assertTrue(firstConnectionDate.toEpochSecond(ZoneOffset.UTC) < connectionRepository.findBySub(USER_SUB).get(0).getLastConnexionDate().toEpochSecond(ZoneOffset.UTC) + 2);
+        assertTrue(firstConnectionDate.toEpochSecond(ZoneOffset.UTC) < connectionRepository.findBySub(USER_SUB).get().getLastConnexionDate().toEpochSecond(ZoneOffset.UTC) + 2);
 
         mockMvc.perform(head("/" + UserAdminApi.API_VERSION + "/users/{sub}", USER_SUB))
                 .andExpect(status().isOk())
                 .andReturn();
-        assertEquals(firstConnectionDate, connectionRepository.findBySub(USER_SUB).get(0).getFirstConnexionDate());
+        assertEquals(firstConnectionDate, connectionRepository.findBySub(USER_SUB).get().getFirstConnexionDate());
 
         mockMvc.perform(delete("/" + UserAdminApi.API_VERSION + "/users/{id}", userId)
                         .header("userId", ADMIN_USER)


### PR DESCRIPTION
Fix duplicate records in database
```sql
select sub, count(*) from useradmin.connection group by sub having count(sub)>1;
+----+-----+
|sub |count|
+----+-----+
|AA3 |4    |
|AB8 |2    |
|J6  |2    |
+----+-----+
```

Also rename column from french "connexion" to english "connection".

Have keep temporally old `ConnectionsService.removeDuplicates()` (marked for removal).