### PR TITLE
Springboot 3.3.3 migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     </developers>
 
     <properties>
-        <gridsuite-dependencies.version>32</gridsuite-dependencies.version>
+        <gridsuite-dependencies.version>33</gridsuite-dependencies.version>
         <liquibase-hibernate-package>org.gridsuite.useradmin.server</liquibase-hibernate-package>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>19</version>
+        <version>20</version>
         <relativePath/>
     </parent>
 
@@ -42,7 +42,7 @@
     </developers>
 
     <properties>
-        <gridsuite-dependencies.version>31</gridsuite-dependencies.version>
+        <gridsuite-dependencies.version>32</gridsuite-dependencies.version>
         <liquibase-hibernate-package>org.gridsuite.useradmin.server</liquibase-hibernate-package>
     </properties>
 
@@ -178,7 +178,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jetty12</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/gridsuite/useradmin/server/UserAdminTest.java
+++ b/src/test/java/org/gridsuite/useradmin/server/UserAdminTest.java
@@ -177,8 +177,15 @@ class UserAdminTest {
         mockMvc.perform(delete("/" + UserAdminApi.API_VERSION + "/users")
                         .header("userId", NOT_ADMIN)
                         .contentType(APPLICATION_JSON)
-                        .content("[]"))
+                        .content("[\"" + USER_SUB + "\"]"))
                 .andExpect(status().isForbidden())
+                .andReturn();
+
+        mockMvc.perform(delete("/" + UserAdminApi.API_VERSION + "/users")
+                        .header("userId", ADMIN_USER)
+                        .contentType(APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isBadRequest())
                 .andReturn();
 
         mockMvc.perform(delete("/" + UserAdminApi.API_VERSION + "/users")


### PR DESCRIPTION
**Problem**: when testing deleteUser controller (which expect not empty list of users) with an **empty list of subs** and **Not admin user** in the header at the same time we get 400 bad request(instead of 403 Forbidden in the previous behavior).

**Solution**: Seperate the two test: one with **empty list of subs** to delete, and one with **Not admin user** in the header