### PR TITLE
Make get groups public

### DIFF
--- a/src/main/java/org/gridsuite/useradmin/server/controller/UserGroupController.java
+++ b/src/main/java/org/gridsuite/useradmin/server/controller/UserGroupController.java
@@ -47,10 +47,10 @@ public class UserGroupController {
     }
 
     @GetMapping(value = "", produces = {MediaType.APPLICATION_JSON_VALUE})
-    @Operation(summary = "get all the groups", description = "Access restricted to users of type: `admin`")
+    @Operation(summary = "get all the groups")
     @ApiResponse(responseCode = "200", description = "The groups set")
-    public ResponseEntity<Set<UserGroup>> getGroups(@RequestHeader("userId") String userId) {
-        return ResponseEntity.ok().body(service.getGroups(userId));
+    public ResponseEntity<Set<UserGroup>> getGroups() {
+        return ResponseEntity.ok().body(service.getGroups());
     }
 
     @GetMapping(value = "/{group}")

--- a/src/main/java/org/gridsuite/useradmin/server/service/UserGroupService.java
+++ b/src/main/java/org/gridsuite/useradmin/server/service/UserGroupService.java
@@ -49,8 +49,7 @@ public class UserGroupService {
     }
 
     @Transactional(readOnly = true)
-    public Set<UserGroup> getGroups(String userId) {
-        adminRightService.assertIsAdmin(userId);
+    public Set<UserGroup> getGroups() {
         List<GroupInfosEntity> groups = userGroupRepository.findAll().stream().toList();
         return groups.stream().map(this::toDto).collect(Collectors.toSet());
     }


### PR DESCRIPTION
We make the endpoint get groups public because we need it when we manage directory permission with a user who is owner but not admin