### PR TITLE
Throw a UserAdminException when deleting a referenced profile

### DIFF
--- a/src/main/java/org/gridsuite/useradmin/server/controller/UserProfileController.java
+++ b/src/main/java/org/gridsuite/useradmin/server/controller/UserProfileController.java
@@ -14,7 +14,6 @@ import jakarta.validation.constraints.NotEmpty;
 import org.gridsuite.useradmin.server.UserAdminApi;
 import org.gridsuite.useradmin.server.dto.UserProfile;
 import org.gridsuite.useradmin.server.service.UserProfileService;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -78,14 +77,10 @@ public class UserProfileController {
     @ApiResponse(responseCode = "404", description = "One or more profile(s) not found")
     @ApiResponse(responseCode = "422", description = "Integrity issue when a profile is still referenced by users")
     public ResponseEntity<Void> deleteProfiles(@RequestBody @NotEmpty List<String> names) {
-        try {
-            if (service.deleteProfiles(names) > 0L) {
-                return ResponseEntity.noContent().build();
-            } else {
-                return ResponseEntity.notFound().build();
-            }
-        } catch (DataIntegrityViolationException e) {
-            return ResponseEntity.unprocessableEntity().build();
+        if (service.deleteProfiles(names) > 0L) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
         }
     }
 }

--- a/src/main/java/org/gridsuite/useradmin/server/error/UserAdminBusinessErrorCode.java
+++ b/src/main/java/org/gridsuite/useradmin/server/error/UserAdminBusinessErrorCode.java
@@ -19,6 +19,7 @@ public enum UserAdminBusinessErrorCode implements BusinessErrorCode {
     USER_ADMIN_USER_ALREADY_EXISTS("useradmin.userAlreadyExists"),
     USER_ADMIN_PROFILE_NOT_FOUND("useradmin.profileNotFound"),
     USER_ADMIN_PROFILE_ALREADY_EXISTS("useradmin.profileAlreadyExists"),
+    USER_ADMIN_PROFILE_STILL_REFERENCED("useradmin.profileStillReferenced"),
     USER_ADMIN_GROUP_NOT_FOUND("useradmin.groupNotFound"),
     USER_ADMIN_GROUP_ALREADY_EXISTS("useradmin.groupAlreadyExists"),
     USER_ADMIN_GROUP_STILL_REFERENCED("useradmin.groupStillReferenced"),

--- a/src/main/java/org/gridsuite/useradmin/server/error/UserAdminException.java
+++ b/src/main/java/org/gridsuite/useradmin/server/error/UserAdminException.java
@@ -49,6 +49,14 @@ public class UserAdminException extends AbstractBusinessException {
         return new UserAdminException(USER_ADMIN_PROFILE_NOT_FOUND, String.format("Profile '%s' was not found", profileId));
     }
 
+    public static UserAdminException profileNotFound(String name) {
+        return new UserAdminException(USER_ADMIN_PROFILE_NOT_FOUND, String.format("Profile '%s' was not found", name));
+    }
+
+    public static UserAdminException profileStillReferenced(String name) {
+        return new UserAdminException(USER_ADMIN_PROFILE_STILL_REFERENCED, String.format("Profile `%s` is still referenced by users", name));
+    }
+
     public static UserAdminException groupAlreadyExists(String name) {
         return new UserAdminException(USER_ADMIN_GROUP_ALREADY_EXISTS, String.format("Group '%s' already exists", name));
     }

--- a/src/main/java/org/gridsuite/useradmin/server/error/UserAdminExceptionHandler.java
+++ b/src/main/java/org/gridsuite/useradmin/server/error/UserAdminExceptionHandler.java
@@ -47,7 +47,8 @@ public class UserAdminExceptionHandler
                  USER_ADMIN_GROUP_ALREADY_EXISTS,
                  USER_ADMIN_ANNOUNCEMENT_INVALID_PERIOD,
                  USER_ADMIN_ANNOUNCEMENT_OVERLAP -> HttpStatus.BAD_REQUEST;
-            case USER_ADMIN_GROUP_STILL_REFERENCED -> HttpStatus.UNPROCESSABLE_ENTITY;
+            case USER_ADMIN_GROUP_STILL_REFERENCED,
+                 USER_ADMIN_PROFILE_STILL_REFERENCED -> HttpStatus.UNPROCESSABLE_ENTITY;
         };
     }
 

--- a/src/main/java/org/gridsuite/useradmin/server/repository/UserInfosRepository.java
+++ b/src/main/java/org/gridsuite/useradmin/server/repository/UserInfosRepository.java
@@ -8,6 +8,8 @@ package org.gridsuite.useradmin.server.repository;
 
 import org.gridsuite.useradmin.server.entity.UserInfosEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
@@ -27,4 +29,7 @@ public interface UserInfosRepository extends JpaRepository<UserInfosEntity, UUID
     long deleteBySub(@NonNull String sub);
 
     long deleteAllBySubIn(@NonNull Collection<String> subs);
+
+    @Query("SELECT COUNT(u) > 0 FROM UserInfosEntity u WHERE u.profile.name = :name")
+    boolean existsByProfileName(@Param("name") @NonNull String name);
 }

--- a/src/main/java/org/gridsuite/useradmin/server/service/UserProfileService.java
+++ b/src/main/java/org/gridsuite/useradmin/server/service/UserProfileService.java
@@ -12,6 +12,7 @@ import org.gridsuite.useradmin.server.UserAdminApplicationProps;
 import org.gridsuite.useradmin.server.error.UserAdminException;
 import org.gridsuite.useradmin.server.dto.UserProfile;
 import org.gridsuite.useradmin.server.entity.UserProfileEntity;
+import org.gridsuite.useradmin.server.repository.UserInfosRepository;
 import org.gridsuite.useradmin.server.repository.UserProfileRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,15 +27,18 @@ import java.util.stream.Stream;
 @Service
 public class UserProfileService {
     private final UserProfileRepository userProfileRepository;
+    private final UserInfosRepository userInfosRepository;
     private final DirectoryService directoryService;
     private final AdminRightService adminRightService;
     private final UserAdminApplicationProps applicationProps;
 
     public UserProfileService(final UserProfileRepository userProfileRepository,
+                              final UserInfosRepository userInfosRepository,
                               final AdminRightService adminRightService,
                               final DirectoryService directoryService,
                               final UserAdminApplicationProps applicationProps) {
         this.userProfileRepository = Objects.requireNonNull(userProfileRepository);
+        this.userInfosRepository = Objects.requireNonNull(userInfosRepository);
         this.adminRightService = Objects.requireNonNull(adminRightService);
         this.directoryService = Objects.requireNonNull(directoryService);
         this.applicationProps = Objects.requireNonNull(applicationProps);
@@ -147,6 +151,15 @@ public class UserProfileService {
     @Transactional
     public long deleteProfiles(List<String> names) {
         adminRightService.assertIsAdmin();
+
+        // check if profile is still referenced by users
+        names.forEach(name -> {
+            userProfileRepository.findByName(name)
+                .orElseThrow(() -> UserAdminException.profileNotFound(name));
+            if (userInfosRepository.existsByProfileName(name)) {
+                throw UserAdminException.profileStillReferenced(name);
+            }
+        });
         return userProfileRepository.deleteAllByNameIn(names);
     }
 


### PR DESCRIPTION
## Summary
- Apply the same pattern introduced for groups (#98) to profiles.
- Replace the `DataIntegrityViolationException` swallowed in `UserProfileController.deleteProfiles` with a typed `UserAdminException.profileStillReferenced(name)` backed by the new `USER_ADMIN_PROFILE_STILL_REFERENCED` business error code, mapped to `HTTP 422` in `UserAdminExceptionHandler`.
- Add an explicit pre-check in `UserProfileService.deleteProfiles` via a new `UserInfosRepository.existsByProfileName` query (JPQL, to comply with the checkstyle rule banning underscores in method names), and resolve each profile by name first to throw `profileNotFound` rather than relying on the DB foreign-key constraint to fail.

> [!NOTE]
> Stacked on top of #98. Set the base back to `main` once #98 lands.